### PR TITLE
Replace deprecated image placeholder #272

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,9 +2,10 @@
 # https://github.com/firebase/firebase-tools
 
 name: "[PR] Deploy to Firebase Hosting on push to PR (isolated test environment)"
-on: pull_request
-branches-ignore:
-  - "dependabot/**"
+on: 
+  pull_request:
+    branches-ignore:
+      - "dependabot/**"
 
 jobs:
   build_and_preview:

--- a/src/components/find-us-on-facebook.js
+++ b/src/components/find-us-on-facebook.js
@@ -7,7 +7,7 @@ import { StaticImage } from "gatsby-plugin-image";
 const alt = "find us on facebook";
 const loading = "lazy";
 const objectFit = "contain";
-const placeholder = "tracedSVG";
+const placeholder = "dominantColor";
 
 const BlueFacebookImage = () => {
   return (

--- a/src/components/hero-section.js
+++ b/src/components/hero-section.js
@@ -12,7 +12,7 @@ const HeroSection = () => {
         loading="eager"
         objectFit="cover"
         layout="fullWidth"
-        placeholder="tracedSVG"
+        placeholder="dominantColor"
       />
       <h1 className={style.centered}>Friends of Foxley</h1>
     </section>


### PR DESCRIPTION
`warn "TRACED_SVG" placeholder argument value is no longer supported (used in gatsbyImageData processing), falling back to "DOMINANT_COLOR". See https://gatsby.dev/tracesvg-removal/`