### PR TITLE
Use reshepe web vitals to track website performance  #293

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -12,6 +12,7 @@ jobs:
   build_and_deploy:
     name: Build and deploy to PROD
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v4
 
@@ -27,6 +28,7 @@ jobs:
         env:
           CONTENTFUL_SPACE_ID: "${{ secrets.CONTENTFUL_SPACE_ID }}"
           CONTENTFUL_DELIVERY_TOKEN: "${{ secrets.CONTENTFUL_DELIVERY_TOKEN }}"
+          GATSBY_RESHEPE_PUBLIC_KEY: "${{ variables.GATSBY_RESHEPE_PUBLIC_KEY }}"
 
       - name: Deploy to PROD site
         uses: FirebaseExtended/action-hosting-deploy@v0
@@ -39,6 +41,7 @@ jobs:
   deploy_preview_api:
     name: Build and deploy to Preview API
     runs-on: ubuntu-latest
+    environment: preview
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -1,0 +1,15 @@
+# Web vitals
+
+Web vitals are being tracked for all traffic using reshepe. It currently has a free tier.
+
+https://reshepe.dev/features/web-vitals
+https://docs.reshepe.dev/web-vitals/introduction
+https://docs.reshepe.dev/web-vitals/javascript
+
+### Config
+
+reshepe web vitals will only track if `GATSBY_RESHEPE_PUBLIC_KEY` env var is set to the correct public key.  This should only be set in PROD, though for troubleshooting we can set the env var locally in the `.env` file.
+
+I tried the react package `@reshepe-web-vitals/react` but it required `react-router-dom` npm package as well. I tried adding it as a peer dependency, but that still didn't work. I didn't want to install `react-router-dom` just for reshepe.
+
+I found that the toolbar didn't work. It loaded the toolbar but with empty stats, and no error in the console. I tried changing the script from defer to async to not specified, and still didn't work

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -56,3 +56,17 @@ export const pageQuery = graphql`
     }
   }
 `;
+
+export function Head() {
+  const reshepeApiKey = process.env.GATSBY_RESHEPE_PUBLIC_KEY;
+
+  if (reshepeApiKey) {
+    return (
+      <script
+        id="reshepe-webvitals"
+        async
+        data-api-key={reshepeApiKey}
+        src="https://cdn.jsdelivr.net/npm/@reshepe-web-vitals/js/dist/index.global.js"></script>
+    );
+  }
+}


### PR DESCRIPTION
I want to track metrics on the friends of foxley website.  Reshepe has a free tier so trying
it out.

I tried the react package `@reshepe-web-vitals/react` but it required `react-router-dom`
npm package as well.  I tried adding it as a peer dependency, but that still didn't work.
I didn't want to install `react-router-dom` just for reshepe.

I used this guide for config
https://docs.reshepe.dev/web-vitals/javascript

I found that the toolbar didn't work.  It loaded the toolbar but with empty stats, and no
error in the console.  I tried changing the script from defer to async to not specified, and
still didn't work