### PR TITLE
Lint github actions workflows

### DIFF
--- a/.github/workflows/lint-github-actions-workflows.yml
+++ b/.github/workflows/lint-github-actions-workflows.yml
@@ -1,0 +1,21 @@
+name: GitHub Actions linter
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  actionlint:
+    name: "Lint GitHub Actions workflows"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          fail_level: error
+          level: warning
+          reporter: github-pr-check


### PR DESCRIPTION
I want to avoid merging syntax errors

Quite a few syntax errors crept into main recently because an extension wasn't enabled
in my IDE.  Having a linter configured to run on push to PR seems sensible to avoid
future isssues


## What happens when there's a syntax error?

The new workflow fails, and you'll see something like this in the run logs
```
e:.github/workflows/firebase-hosting-merge.yml:31:43: undefined variable "variables". available variables are "env", "github", "inputs", "job", "matrix", "needs", "runner", "secrets", "steps", "strategy", "vars" [expression]
reviewdog: found at least one issue with severity greater than or equal to the given level: error
```
In the PR you'll see an annotation:
![image](https://github.com/user-attachments/assets/efe7bda2-c035-4078-9024-79e69f723522)
