### PR TITLE
Marked SEO component as deprecated #291

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "module": "ESNext",
+        "baseUrl": ".",
+        "paths": {
+            "*": [
+                "src/*"
+            ]
+        }
+    },
+    "exclude": [
+        ".cache",
+        ".yarn",
+        "node_modules",
+        "build",
+        "dist",
+        "docs",
+        "public",
+    ]
+}

--- a/src/components/deprecated-seo-component.js
+++ b/src/components/deprecated-seo-component.js
@@ -10,19 +10,18 @@ import PropTypes from "prop-types";
 import { Helmet } from "react-helmet";
 import { useStaticQuery, graphql } from "gatsby";
 
-const Seo = ({ description, lang, meta, title }) => {
-  const { site } = useStaticQuery(
-    graphql`
-      query {
-        site {
-          siteMetadata {
-            title
-            description
-          }
+/** @deprecated gatsby-plugin-react-helmet package is deprecated, this component needs to be re-written */
+const DeprecatedSeoComponent = ({ description, lang, meta, title }) => {
+  const { site } = useStaticQuery(graphql`
+    query {
+      site {
+        siteMetadata {
+          title
+          description
         }
       }
-    `,
-  );
+    }
+  `);
 
   const metaDescription = description || site.siteMetadata.description;
   const defaultTitle = site.siteMetadata?.title;
@@ -56,17 +55,17 @@ const Seo = ({ description, lang, meta, title }) => {
   );
 };
 
-Seo.defaultProps = {
+DeprecatedSeoComponent.defaultProps = {
   lang: `en`,
   meta: [],
   description: ``,
 };
 
-Seo.propTypes = {
+DeprecatedSeoComponent.propTypes = {
   description: PropTypes.string,
   lang: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
   title: PropTypes.string.isRequired,
 };
 
-export default React.memo(Seo);
+export default React.memo(DeprecatedSeoComponent);

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -2,14 +2,14 @@ import * as React from "react";
 import { graphql } from "gatsby";
 
 import Layout from "../components/layout";
-import Seo from "../components/seo";
+import DeprecatedSeoComponent from "../components/deprecated-seo-component";
 
 const NotFoundPage = ({ data, location }) => {
   const siteTitle = data?.site?.siteMetadata?.title || "Not found";
 
   return (
     <Layout location={location} title={siteTitle} showHeroSection>
-      <Seo title="404: Not Found" />
+      <DeprecatedSeoComponent title="404: Not Found" />
       <h1>Couldn't find that page</h1>
       <p>Check the URL and try again. Our woods aren't that big!</p>
       <p>{location.pathname}</p>

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { graphql } from "gatsby";
 import Layout from "../components/layout";
-import Seo from "../components/seo";
+import DeprecatedSeoComponent from "../components/deprecated-seo-component";
 import * as style from "./contact.module.css";
 import FindUsOnFacebook from "../components/find-us-on-facebook";
 
@@ -11,7 +11,7 @@ const ContactIndex = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo title="Contact" />
+      <DeprecatedSeoComponent title="Contact" />
       <h1>Contact us</h1>
       <div className={style.facebookSpacing}>
         <FindUsOnFacebook useWhiteGraphic={false} />

--- a/src/pages/history.js
+++ b/src/pages/history.js
@@ -1,14 +1,14 @@
 import * as React from "react";
 import { graphql } from "gatsby";
 import Layout from "../components/layout";
-import Seo from "../components/seo";
+import DeprecatedSeoComponent from "../components/deprecated-seo-component";
 
 const HistoryIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`;
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo title="History" />
+      <DeprecatedSeoComponent title="History" />
       <h1>History of Foxley Wood</h1>
       <p>
         The ancient name FOXLE first appears in the Surrey Assize Rolls of 1279

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,14 +1,14 @@
 import * as React from "react";
 import { graphql, Link } from "gatsby";
 import Layout from "../components/layout";
-import Seo from "../components/seo";
+import DeprecatedSeoComponent from "../components/deprecated-seo-component";
 
 const HomeIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`;
 
   return (
     <Layout location={location} title={siteTitle} showHeroSection>
-      <Seo title={siteTitle} />
+      <DeprecatedSeoComponent title={siteTitle} />
       <p>
         The Friends Of Foxley are a group of local people who work in
         partnership with Croydon Council to protect and manage the nature

--- a/src/pages/news.js
+++ b/src/pages/news.js
@@ -3,7 +3,7 @@ import { Link, graphql } from "gatsby";
 
 import Bio from "../components/bio";
 import Layout from "../components/layout";
-import Seo from "../components/seo";
+import DeprecatedSeoComponent from "../components/deprecated-seo-component";
 import * as style from "./posts.module.css";
 
 const NewsIndex = ({ data, location }) => {
@@ -13,7 +13,7 @@ const NewsIndex = ({ data, location }) => {
   if (posts.length === 0) {
     return (
       <Layout location={location} title={siteTitle}>
-        <Seo title="News" />
+        <DeprecatedSeoComponent title="News" />
         <Bio />
         <p>No news posts found. Add posts to contentful.</p>
       </Layout>
@@ -22,7 +22,7 @@ const NewsIndex = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo title="News" />
+      <DeprecatedSeoComponent title="News" />
       <h1>Latest news</h1>
 
       {posts.map(post => {

--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { graphql } from "gatsby";
 import Layout from "../components/layout";
-import Seo from "../components/seo";
+import DeprecatedSeoComponent from "../components/deprecated-seo-component";
 import * as style from "./resources.module.css";
 
 const ResourcesIndex = ({ data, location }) => {
@@ -11,7 +11,7 @@ const ResourcesIndex = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo title="Resources" />
+      <DeprecatedSeoComponent title="Resources" />
       <h1>{resourcesPageData.title}</h1>
 
       <p>{resourcesPageData?.subTitle}</p>

--- a/src/pages/trees.js
+++ b/src/pages/trees.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { graphql, Link } from "gatsby";
 import Layout from "../components/layout";
-import Seo from "../components/seo";
+import DeprecatedSeoComponent from "../components/deprecated-seo-component";
 import ExternalLink from "../components/external-link";
 
 const TreesIndex = ({ data, location }) => {
@@ -9,12 +9,12 @@ const TreesIndex = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo title="Trees" />
+      <DeprecatedSeoComponent title="Trees" />
       <h1>Trees of Foxley Wood</h1>
 
       <p>
         Here are the most prominent trees that make Foxley Wood such a special
-        Local Nature Reserve. 
+        Local Nature Reserve.
       </p>
 
       <ul>

--- a/src/pages/trees/ancient-beech-tree-diversion.js
+++ b/src/pages/trees/ancient-beech-tree-diversion.js
@@ -1,14 +1,14 @@
 import * as React from "react";
 import { graphql } from "gatsby";
 import Layout from "../../components/layout";
-import Seo from "../../components/seo";
+import DeprecatedSeoComponent from "../../components/deprecated-seo-component";
 
 const AncientBeechTreeIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`;
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo title="ancient beech tree" />
+      <DeprecatedSeoComponent title="ancient beech tree" />
       <h1>Ancient Beech Tree Diversion</h1>
       <h2>
         Reasons for the path diversion and fencing around the Ancient Beech

--- a/src/pages/trees/english-oak.js
+++ b/src/pages/trees/english-oak.js
@@ -1,14 +1,14 @@
 import * as React from "react";
 import { graphql } from "gatsby";
 import Layout from "../../components/layout";
-import Seo from "../../components/seo";
+import DeprecatedSeoComponent from "../../components/deprecated-seo-component";
 
 const EnglishOakTreeIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`;
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo title="English Oak Tree" />
+      <DeprecatedSeoComponent title="English Oak Tree" />
       <h1>English Oak Tree</h1>
       <h2>Other names - Common Oak, Pedunculate Oak, European Oak</h2>
       <p>

--- a/src/pages/trees/wych-elm.js
+++ b/src/pages/trees/wych-elm.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { graphql } from "gatsby";
 import Layout from "../../components/layout";
-import Seo from "../../components/seo";
+import DeprecatedSeoComponent from "../../components/deprecated-seo-component";
 import ExternalLink from "../../components/external-link";
 
 const Index = ({ data, location }) => {
@@ -9,7 +9,7 @@ const Index = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo title="Wych Elm Tree" />
+      <DeprecatedSeoComponent title="Wych Elm Tree" />
       <h1>Wych Elm Tree</h1>
       <h2>Other names - Ulmus glabra, Scots elm</h2>
       <p>

--- a/src/pages/wood-products.js
+++ b/src/pages/wood-products.js
@@ -2,14 +2,14 @@ import * as React from "react";
 import { graphql, Link } from "gatsby";
 import { StaticImage } from "gatsby-plugin-image";
 import Layout from "../components/layout";
-import Seo from "../components/seo";
+import DeprecatedSeoComponent from "../components/deprecated-seo-component";
 
 const Index = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`;
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo title="Wood Products" />
+      <DeprecatedSeoComponent title="Wood Products" />
       <h1>Wood Products</h1>
 
       <p>

--- a/src/pages/work-days.js
+++ b/src/pages/work-days.js
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Link, graphql } from "gatsby";
 
 import Layout from "../components/layout";
-import Seo from "../components/seo";
+import DeprecatedSeoComponent from "../components/deprecated-seo-component";
 import * as style from "./posts.module.css";
 
 const WorkDaysIndex = ({ data, location }) => {
@@ -12,7 +12,7 @@ const WorkDaysIndex = ({ data, location }) => {
   if (posts.length === 0) {
     return (
       <Layout location={location} title={siteTitle}>
-        <Seo title="Volunteer workdays" />
+        <DeprecatedSeoComponent title="Volunteer workdays" />
         <p>No news posts found. Add posts to contentful.</p>
       </Layout>
     );
@@ -20,7 +20,7 @@ const WorkDaysIndex = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo title="Work Days and Volunteering" />
+      <DeprecatedSeoComponent title="Work Days and Volunteering" />
 
       <h1>Work Days and Volunteering</h1>
 

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -3,7 +3,7 @@ import { Link, graphql } from "gatsby";
 
 import Bio from "../components/bio";
 import Layout from "../components/layout";
-import Seo from "../components/seo";
+import DeprecatedSeoComponent from "../components/deprecated-seo-component";
 import * as style from "./blog-post.module.css";
 import { renderRichText } from "gatsby-source-contentful/rich-text";
 import { contentfulRenderingOptions } from "../helpers/contentful-rendering-options";
@@ -16,7 +16,7 @@ const BlogPostTemplate = ({ data, location }) => {
   return (
     // <script src="https://assets.what3words.com/sdk/v3/what3words.js"></script>
     <Layout location={location} title={siteTitle}>
-      <Seo
+      <DeprecatedSeoComponent
         title={post.title}
         // description={post.newsContent.raw || post.excerpt}
       />

--- a/src/templates/work-day-information.js
+++ b/src/templates/work-day-information.js
@@ -3,7 +3,7 @@ import { Link, graphql } from "gatsby";
 
 import Bio from "../components/bio";
 import Layout from "../components/layout";
-import Seo from "../components/seo";
+import DeprecatedSeoComponent from "../components/deprecated-seo-component";
 import { What3wordsAddress } from "@what3words/react-components";
 import { renderRichText } from "gatsby-source-contentful/rich-text";
 import { parseMeetingPoint } from "../helpers/parse-meeting-point";
@@ -21,7 +21,10 @@ const WorkDayTemplate = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo title={post.title} description={post.description || post.excerpt} />
+      <DeprecatedSeoComponent
+        title={post.title}
+        description={post.description || post.excerpt}
+      />
       <article
         className="blog-post"
         itemScope


### PR DESCRIPTION
This is the first step in replacing `gatsby-plugin-react-helmet`.

I will create a new SEO component and use on a page following the new pattern.  I need to check
the SEO doesn't get broken in swapping over

> gatsby-plugin-react-helmet: Gatsby now has built-in support for modifying the document head.

> The gatsby-plugin-react-helmet package will be deprecated in the future. The new Gatsby Head
> API is easier to use, more performant, has a smaller bundle size, and supports the latest React
> features. Update to gatsby@^4.19.0 to use it.